### PR TITLE
remove @ for greeting message

### DIFF
--- a/doorman/guess.py
+++ b/doorman/guess.py
@@ -74,7 +74,7 @@ def guess(event, context):
 
         data = {
             "channel": slack_channel_id,
-            "text": "Welcome @%s" % username,
+            "text": "Welcome %s" % username,
             "link_names": True,
             "attachments": [
                 {


### PR DESCRIPTION
Per Ryan Hammond's feature request, remove the direct message @ from the doorman greeting.